### PR TITLE
Use atty instead of isatty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ categories = ["command-line-interface"]
 
 [dependencies]
 codemap = { version = "0.1.0" }
-isatty = "0.1.3"
+atty = "0.2.11"
 term = "0.4"

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -14,7 +14,7 @@ use std::cmp::min;
 use std::sync::Arc;
 use std::collections::HashMap;
 use term;
-use isatty::stderr_isatty;
+use atty::{self, Stream};
 
 use { Level, Diagnostic, SpanLabel, SpanStyle };
 use codemap::{CodeMap, File};
@@ -39,7 +39,7 @@ impl ColorConfig {
         match *self {
             ColorConfig::Always => true,
             ColorConfig::Never => false,
-            ColorConfig::Auto => stderr_isatty(),
+            ColorConfig::Auto => atty::is(Stream::Stderr),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 
 extern crate term;
 extern crate codemap;
-extern crate isatty;
+extern crate atty;
 
 use codemap::Span;
 


### PR DESCRIPTION
`isatty` has been deprecated and encourages people to move to `atty` instead.