### PR TITLE
Support WebAssembly by tweaking `acquire_global_lock` guard.

### DIFF
--- a/src/lock.rs
+++ b/src/lock.rs
@@ -109,7 +109,7 @@ pub fn acquire_global_lock(name: &str) -> Box<Any> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 pub fn acquire_global_lock(_name: &str) -> Box<Any> {
     Box::new(())
 }


### PR DESCRIPTION
`acquire_global_lock()` has two implementations (UNIX and Windows), with the UNIX one stubbed out. I changed the compilation guard to make the stub used for non-Windows so it'll also build in WebAssembly model