### PR TITLE
Migrate fixes from rustc_errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ categories = ["command-line-interface"]
 [dependencies]
 codemap = { version = "0.1.0" }
 atty = "0.2.11"
-term = "0.4"
+termcolor = "1.0.4"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -28,6 +28,6 @@ pub fn look_up_pos(&self, pos: Pos) -> Loc {
 
     let d3 = Diagnostic { level: Level::Help, message:"Help message".to_owned(), code: None, spans: vec![] };
 
-    let mut emitter = Emitter::stderr(ColorConfig::Always, Some(&codemap));
+    let mut emitter = Emitter::stderr(ColorConfig::Auto, Some(&codemap));
     emitter.emit(&[d1, d2, d3]);
 }

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -389,8 +389,11 @@ impl<'a> Emitter<'a> {
                             && next.has_label())     // multiline start/end, move it to a new line
                         || (annotation.has_label()   // so as not to overlap the orizontal lines.
                             && next.takes_space())
-                        || (annotation.takes_space()
-                            && next.takes_space())
+                        || (annotation.takes_space() && next.takes_space())
+                        || (overlaps(next, annotation, l)
+                            && next.end_col <= annotation.end_col
+                            && next.has_label()
+                            && p == 0)  // Avoid #42595.
                     {
                         // This annotation needs a new line in the output.
                         p += 1;

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -247,7 +247,9 @@ impl<'a> Emitter<'a> {
         if line.annotations.len() == 1 {
             if let Some(ref ann) = line.annotations.get(0) {
                 if let AnnotationType::MultilineStart(depth) = ann.annotation_type {
-                    if source_string[0..ann.start_col].trim() == "" {
+                    if source_string.chars()
+                                    .take(ann.start_col)
+                                    .all(|c| c.is_whitespace()) {
                         let style = if ann.is_primary {
                             Style::UnderlinePrimary
                         } else {

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -283,9 +283,19 @@ impl<'a> Emitter<'a> {
         // and "annotations lines", where the highlight lines have the `^`.
 
         // Sort the annotations by (start, end col)
+        // The labels are reversed, sort and then reversed again.
+        // Consider a list of annotations (A1, A2, C1, C2, B1, B2) where
+        // the letter signifies the span. Here we are only sorting by the
+        // span and hence, the order of the elements with the same span will
+        // not change. On reversing the ordering (|a, b| but b.cmp(a)), you get
+        // (C1, C2, B1, B2, A1, A2). All the elements with the same span are
+        // still ordered first to last, but all the elements with different
+        // spans are ordered by their spans in last to first order. Last to
+        // first order is important, because the jiggly lines and | are on
+        // the left, so the rightmost span needs to be rendered first,
+        // otherwise the lines would end up needing to go over a message.
         let mut annotations = line.annotations.clone();
-        annotations.sort();
-        annotations.reverse();
+        annotations.sort_by(|a,b| b.start_col.cmp(&a.start_col));
 
         // First, figure out where each label will be positioned.
         //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! }
 //! ```
 
-extern crate term;
+extern crate termcolor;
 extern crate codemap;
 extern crate atty;
 
@@ -44,6 +44,7 @@ mod styled_buffer;
 mod emitter;
 
 pub use emitter::{ ColorConfig, Emitter };
+use termcolor::{ ColorSpec, Color };
 
 /// A diagnostic message.
 #[derive(Clone, Debug)]
@@ -80,20 +81,28 @@ impl ::std::fmt::Display for Level {
 }
 
 impl Level {
-    fn color(self) -> term::color::Color {
+    fn color(self) -> ColorSpec {
+        let mut spec = ColorSpec::new();
         use self::Level::*;
         match self {
-            Bug | Error => term::color::BRIGHT_RED,
-            Warning => {
-                if cfg!(windows) {
-                    term::color::BRIGHT_YELLOW
-                } else {
-                    term::color::YELLOW
-                }
+            Bug | Error => {
+                spec.set_fg(Some(Color::Red))
+                    .set_intense(true);
             }
-            Note => term::color::BRIGHT_GREEN,
-            Help => term::color::BRIGHT_CYAN,
+            Warning => {
+                spec.set_fg(Some(Color::Yellow))
+                    .set_intense(cfg!(windows));
+            }
+            Note => {
+                spec.set_fg(Some(Color::Green))
+                    .set_intense(true);
+            }
+            Help => {
+                spec.set_fg(Some(Color::Cyan))
+                    .set_intense(true);
+            }
         }
+        spec
     }
 
     pub fn to_str(self) -> &'static str {


### PR DESCRIPTION
Quickly looking through the [git history for the upstream rustc code this is based on](https://github.com/rust-lang/rust/commits/master/src/librustc_errors/emitter.rs), I grabbed all the fixes that looked relevant and reasonably easy to port.

The remaining one that looks relevant that I skipped due to size is https://github.com/rust-lang/rust/commit/272c2faa1d766fd4185141106959cdb58b88e6e9. (note: there are some later commits that appear to fix bugs introduced by that one).