### PR TITLE
Add PartialEq/Eq for Diagnostic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub use emitter::{ ColorConfig, Emitter };
 use termcolor::{ ColorSpec, Color };
 
 /// A diagnostic message.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Diagnostic {
     /// The severity of the message, used to set color scheme
     pub level: Level,
@@ -119,7 +119,7 @@ impl Level {
 }
 
 /// A labeled region of the code related to a Diagnostic.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SpanLabel {
     /// The location in the code.
     ///


### PR DESCRIPTION
These traits would be super useful for me. While the PartialEq/Eq are useful in their own right, I'm also finding great use for them by doing:

```
fn mycompile(...) -> Result<bool, Diagnostic> {...}

assert_eq!(mycompile(...), Ok(true));
```

Now when `mycompile` fails I can easily get the LHS, and thus the compile error message, which is a very way to write tests.